### PR TITLE
⬆️ Updated from JUnit 4 to JUnit 5

### DIFF
--- a/com.adobe.granite.ide.eclipse-ui/pom.xml
+++ b/com.adobe.granite.ide.eclipse-ui/pom.xml
@@ -75,11 +75,11 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.13.4</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.apache.maven.shared</groupId>
 			<artifactId>maven-shared-utils</artifactId>

--- a/com.adobe.granite.ide.eclipse-ui/src/test/java/com/adobe/granite/ide/eclipse/ui/wizards/np/PropUtilsTest.java
+++ b/com.adobe.granite.ide.eclipse-ui/src/test/java/com/adobe/granite/ide/eclipse/ui/wizards/np/PropUtilsTest.java
@@ -1,16 +1,17 @@
 package com.adobe.granite.ide.eclipse.ui.wizards.np;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.maven.archetype.metadata.RequiredProperty;
+
 import org.apache.maven.shared.utils.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("restriction")
-public class PropUtilsTest {
+class PropUtilsTest {
 
 	private Map<String, RequiredPropertyWrapper> getProperties(String[][] props) {
 		Map<String, RequiredPropertyWrapper> properties = new LinkedHashMap<String, RequiredPropertyWrapper>();
@@ -25,9 +26,9 @@ public class PropUtilsTest {
 		}
 		return properties;
 	}
-	
+
     @Test
-    public void testUpdateProperties() {
+    void updateProperties() {
     	Map<String, RequiredPropertyWrapper> properties = getProperties(new String[][] {
     		new String[] {
     				"unmodified", "", "DEFAULT_UNMODIFIED", ""
@@ -82,6 +83,6 @@ public class PropUtilsTest {
     }
 	
 	private String pad(Object obj) {
-		return StringUtils.rightPad(StringUtils.defaultString(String.valueOf(obj), ""), 30);
+		return StringUtils.rightPad(String.valueOf(obj), 30);
 	}
 }


### PR DESCRIPTION
Migrate from JUnit 4 to JUnit 5 

## Description

Updated pom.xml and the single unit test.  Made the test methods package private and removed the "test" prefix in method name, per JUnit 5 best practices.

## Related Issue

#125 

## Motivation and Context

JUnit 4 was been replaced by JUnit 5 approximately 8 years ago.

## How Has This Been Tested?

Ran `maven verify` to prove the tests still pass.

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
