### PR TITLE
chore(deps): require version 1.3.0 of the Sling IDE Tooling

### DIFF
--- a/com.adobe.granite.ide.feature/feature.xml
+++ b/com.adobe.granite.ide.feature/feature.xml
@@ -210,9 +210,9 @@
    </license>
 
    <requires>
-      <import feature="org.apache.sling.ide.feature" version="1.2.2" match="greaterOrEqual"/>
-      <import feature="org.apache.sling.ide.m2e.feature" version="1.2.2" match="greaterOrEqual"/>
-      <import feature="org.apache.sling.ide.sightly.feature" version="1.2.2" match="greaterOrEqual"/>
+      <import feature="org.apache.sling.ide.feature" version="1.3.0" match="compatible"/>
+      <import feature="org.apache.sling.ide.m2e.feature" version="1.3.0" match="compatible"/>
+      <import feature="org.apache.sling.ide.sightly.feature" version="1.3.0" match="compatible"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Require version 1.3.0 of the Sling IDE Tooling and make the version match 'compatible', which does not accept a higher version with a different major version level.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#103 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Prevent installation errors by requring the latest version of the Sling IDE tooling.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
